### PR TITLE
Refactor of delegate.od

### DIFF
--- a/delegate.od
+++ b/delegate.od
@@ -3,7 +3,12 @@
 #
 # Our job is then to delegate the work the right .do file inside $SRCDIR,
 # if any.
-redo-use-whichdo(){
+
+
+# redo-find-dofile src/path/outfile.x -> e.g. src/default.x.do
+# redo-find-dofile: wrapper for redo-whichdo that only prints which .do,
+#                   and establishes dependencies on the source path up to it
+redo-find-dofile() {
     redo-whichdo "$1" | {
         ifcreate=
         while read dopath; do
@@ -17,7 +22,32 @@ redo-use-whichdo(){
         done
     }
 }
-redo-run(){
+
+# redo-basename src/path/outfile.x.y default.y.do -> src/path/outfile.x
+# redo-basename: synthesize $2 as would have been passed to dofile in
+#   redo src/path/outfile.x.y
+# by stripping the correct set of extensions
+redo-basename() {
+    x1=$1; dofile=$2
+    # Calculate the $2 relative path.
+    # We can't start with $2 here, because we were called from
+    # default.do and redo-whichdo might have afound a default.o.do,
+    # for example.  We have to strip the extension from $1 ourselves.
+    dofile=${dofile##*/}
+    ext=${dofile##*default}
+    if [ "$ext" != "$dofile"]; then
+      ext=${ext%.do}
+      echo "${x1%ext}"
+    else
+      echo "$x1"
+    fi
+}
+
+# redo-run dofile.do src/path/srcname.x srcname output/file.y
+# redo-run: synthetically run a .do script, as if
+#   redo output/file.y
+# had invoked it to build output/file.y from src/path/srcname.x
+redo-run() {
     dofile=$1; shift
     x1=$1; x2=$2; x3=$3
     # This is slightly faster than forking $(dirname) and $(basename),
@@ -43,23 +73,8 @@ redo-run(){
     . "./$dofile"
 }
 
-redo-basename(){
-    x1=$1; dofile=$2
-    # Calculate the $2 relative path.
-    # We can't start with $2 here, because we were called from
-    # default.do and redo-whichdo might have afound a default.o.do,
-    # for example.  We have to strip the extension from $1 ourselves.
-    dofile=${dofile##*/}
-    ext=${dofile##*default}
-    if [ "$ext" != "$dofile"]; then
-      ext=${ext%.do}
-      echo "${x1%ext}"
-    else
-      echo "$x1"
-    fi
-}
-
 OUT=$PWD
 cd "$SRCDIR"
-whichdo=$(redo-use-whichdo "$1")
-redo-run "$whichdo" "$1" "$(redo-basename "$1" "$whichdo")" "$OUT/$3"
+dofile=$(redo-use "$1")
+basename=$(redo-basename "$1" "$dofile")
+redo-run "$dofile" "$1" "$basename" "$OUT/$3"

--- a/delegate.od
+++ b/delegate.od
@@ -11,7 +11,7 @@
 redo-find-dofile() {
     redo-whichdo "$1" | {
         ifcreate=
-        while read dopath; do
+        while read -r dopath; do
             if [ ! -e "$dopath" ]; then
                 ifcreate="$ifcreate $dopath"
             else
@@ -35,7 +35,7 @@ redo-basename() {
     # for example.  We have to strip the extension from $1 ourselves.
     dofile=${dofile##*/}
     ext=${dofile##*default}
-    if [ "$ext" != "$dofile"]; then
+    if [ "$ext" != "$dofile" ]; then
       ext=${ext%.do}
       echo "${x1%ext}"
     else
@@ -48,7 +48,7 @@ redo-basename() {
 #   redo output/file.y
 # had invoked it to build output/file.y from src/path/srcname.x
 redo-run() {
-    dofile=$1; shift
+    dopath=$1; shift
     x1=$1; x2=$2; x3=$3
     # This is slightly faster than forking $(dirname) and $(basename),
     # plus doesn't try to do any magic like using '.' for an empty
@@ -58,7 +58,7 @@ redo-run() {
 
     # .do files always expect to be run with $PWD set to their own
     # directory.
-    cd "$dodir"
+    cd "$dodir" || exit 1
 
     # Calculate the $1 path relative to the new $dodir.
     # Note: if $dodir is nonempty, it will have a trailing slash,
@@ -74,7 +74,7 @@ redo-run() {
 }
 
 OUT=$PWD
-cd "$SRCDIR"
+cd "$SRCDIR" || exit 1
 dofile=$(redo-use "$1")
 basename=$(redo-basename "$1" "$dofile")
 redo-run "$dofile" "$1" "$basename" "$OUT/$3"

--- a/delegate.od
+++ b/delegate.od
@@ -3,57 +3,63 @@
 #
 # Our job is then to delegate the work the right .do file inside $SRCDIR,
 # if any.
-OUT=$PWD
-ofile=$PWD/$3
-x1=$1
-cd "$SRCDIR"
-redo-whichdo "$x1" | {
-    ifcreate=
-    while read dopath; do
-        if [ ! -e "$dopath" ]; then
-            ifcreate="$ifcreate $dopath"
-        else
-            redo-ifcreate $ifcreate
-            redo-ifchange "$dopath"
-
-            # This is slightly faster than forking $(dirname) and $(basename),
-            # plus doesn't try to do any magic like using '.' for an empty
-            # dir field.
-            dofile=${dopath##*/}
-            dodir=${dopath%$dofile}
-
-            # Calculate the $1 path relative to the new $dodir.
-            # Note: if $dodir is nonempty, it will have a trailing slash,
-            # because of the way it's constructed.
-            #
-            # What we want is to run $dofile from $dodir in the *source*
-            # directory.  We then lie a bit in $1/$2: we provide a relative
-            # path to where we expect the *source* file to reside, even though
-            # $3 will actually end up putting the output at the same relative
-            # path inside $OUT.
-            x1_rel=${x1#$dodir}
-
-            # Calculate the $2 relative path.
-            # We can't start with $2 here, because we were called from
-            # default.do and redo-whichdo might have afound a default.o.do,
-            # for example.  We have to strip the extension from $1 ourselves.
-            ext=${dofile##*default}
-            if [ "$ext" != "$dofile" ]; then
-                ext=${ext%.do}
+redo-use-whichdo(){
+    redo-whichdo "$1" | {
+        ifcreate=
+        while read dopath; do
+            if [ ! -e "$dopath" ]; then
+                ifcreate="$ifcreate $dopath"
             else
-                ext=''
+                redo-ifcreate $ifcreate
+                redo-ifchange "$dopath"
+                echo "$dopath"
             fi
-            x2_rel=${x1#$dodir}
-            x2_rel=${x2_rel%$ext}
-
-            # .do files always expect to be run with $PWD set to their own
-            # directory.
-            cd "$dodir"
-
-            set -- "$x1_rel" "$x2_rel" "$ofile"
-            . "./$dofile"
-            exit
-        fi
-    done
-    exit 3
+        done
+    }
 }
+redo-run(){
+    dofile=$1; shift
+    x1=$1; x2=$2; x3=$3
+    # This is slightly faster than forking $(dirname) and $(basename),
+    # plus doesn't try to do any magic like using '.' for an empty
+    # dir field.
+    dofile=${dopath##*/}
+    dodir=${dopath%$dofile}
+
+    # .do files always expect to be run with $PWD set to their own
+    # directory.
+    cd "$dodir"
+
+    # Calculate the $1 path relative to the new $dodir.
+    # Note: if $dodir is nonempty, it will have a trailing slash,
+    # because of the way it's constructed.
+    #
+    # What we want is to run $dofile from $dodir in the *source*
+    # directory.  We then lie a bit in $1/$2: we provide a relative
+    # path to where we expect the *source* file to reside, even though
+    # $3 will actually end up putting the output at the same relative
+    # path inside $OUT.
+    set -- "${x1#$dodir}" "${x2#$dodir}" "$x3"
+    . "./$dofile"
+}
+
+redo-basename(){
+    x1=$1; dofile=$2
+    # Calculate the $2 relative path.
+    # We can't start with $2 here, because we were called from
+    # default.do and redo-whichdo might have afound a default.o.do,
+    # for example.  We have to strip the extension from $1 ourselves.
+    dofile=${dofile##*/}
+    ext=${dofile##*default}
+    if [ "$ext" != "$dofile"]; then
+      ext=${ext%.do}
+      echo "${x1%ext}"
+    else
+      echo "$x1"
+    fi
+}
+
+OUT=$PWD
+cd "$SRCDIR"
+whichdo=$(redo-use-whichdo "$1")
+redo-run "$whichdo" "$1" "$(redo-basename "$1" "$whichdo")" "$OUT/$3"


### PR DESCRIPTION
`delegate.od` is the third-largest [redo](https://github.com/apenwarr/redo)-related file in the repository, and contains considerably more complexity(/generality) than `_config.od.in` or `libwvbase.list.do`. Following some redo mailing list discussion, this is my attempt to decompose it into independent functions.

Note: I have not attempted to run this code, or otherwise set up an environment capable of building wvstreams. Mostly this is a draft, with best-effort preservation of semantics, submitted to @apenwarr for regularization to local coding style and/or commentary on the ergonomics of *redo* as a tool :)